### PR TITLE
[Resolves #9] use the profile passed to sceptre

### DIFF
--- a/resolver/rcmd.py
+++ b/resolver/rcmd.py
@@ -14,9 +14,14 @@ def build_expression(args, profile):
     :param profile: the AWS profile to execute with
     :return: the expression to execute
     '''
-    expression = None
-    if isinstance(args, dict):
+    if not args:
+        raise ValueError("Missing the command to execute")
 
+    if not profile:
+        profile = os.environ.get("AWS_PROFILE")
+
+    expression = args
+    if isinstance(expression, dict):
         try:
             expression = args['command']
             if not expression:
@@ -26,15 +31,9 @@ def build_expression(args, profile):
 
         if 'profile' in args:
             # override default profile
-            expression = f"AWS_PROFILE={args['profile']} {expression}"
-        else:
-            expression = f"AWS_PROFILE={profile} {expression}"
+            profile = args['profile']
 
-    else:
-        if not args:
-            raise ValueError("Missing the command to execute")
-
-        expression = args
+    expression = f"AWS_PROFILE={profile} {expression}"
 
     return expression
 

--- a/resolver/rcmd.py
+++ b/resolver/rcmd.py
@@ -7,9 +7,10 @@ import subprocess
 
 def build_expression(args, profile):
     '''
-    Build the command that will get executed.  The input argument is only used
-    when args is passed in as a dictionary containing command and profile.
-    If the args is passed in as a string the profile is ignored.
+    Build the command that will get executed. The expression always contains
+    an AWS profile. By default, the profile that the command is executed with
+    is the one that is used to run sceptre. The user can override that profile
+    by setting an alternate profile in the `profile` parameter.
     :param args: input arguments
     :param profile: the AWS profile to execute with
     :return: the expression to execute
@@ -45,7 +46,7 @@ class SceptreResolverCmd(Resolver):
 
     def resolve(self):
         '''
-        Executes a command in an environment shell
+        Executes a command in an environment shell.
         :return: the resulting output from the executed command
         '''
         expression = build_expression(self.argument, self.stack.profile)


### PR DESCRIPTION
This change makes sceptre run this resolver with the
same profile that is passed into sceptre by default.
It will also allow overriding the profile both with
`--var profile` flag and `AWS_PROFILE` environment
variable.