### PR TITLE
Replacing packaging requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 <!--- Example CHANGELOG entry
 
+## 1.2.1
+
+### Changed
+
+- Replaced pinned `packaging` requirement with `sceptre` >=2.7
+
 ## 0.1.0 (2019.07.02)
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,11 @@ bumpversion==0.5.3
 coverage==4.4.2
 pre-commit>=2.12.0,<2.13
 mock==2.0.0
-packaging==16.8
 pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0,<3.3.0
 readme-renderer>=24.0
 setuptools>=40.6.2
-git+git://github.com/sceptre/sceptre.git@master#egg=sceptre
+sceptre>=2.7
 tox>=2.9.1,<3.0.0
 twine>=1.12.1
 wheel==0.32.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 # More information on setting values:
 # https://github.com/Sceptre/project/wiki/sceptre-resolver-template
@@ -25,7 +25,7 @@ with open("README.md") as readme_file:
     README = readme_file.read()
 
 install_requirements = [
-    "packaging==16.8",
+    "sceptre>=2.7",
 ]
 
 test_requirements = [


### PR DESCRIPTION
We need to remove the pinned version of packaging in order to support updating it in Sceptre. In any case, we shouldn't have ever pinned it. There's nothing in this package that actually makes use of packaging as a requirement.